### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,7 @@ impl Default for OutputFormats {
     clap::AppSettings::NextLineHelp]),
     usage("[FLAGS] [OPTIONS] [INPUT] [OUTPUTS...]")
 )]
+#[allow(dead_code)]
 struct Interactive {
     #[structopt(flatten)]
     cli: Cli,


### PR DESCRIPTION
The `Interactive` struct has fields required for code generation but are not explicitly used in the module, so there is a dead code warning from clippy. An ignore directive has been added.